### PR TITLE
Firebase から 単一のページ情報を取得して _id.vue で表示

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,7 +5,7 @@
       v-for="(post, index) in posts"
       :key="index"
     >
-      <p>ポストID: {{ post.postId }}</p>
+      <p @click="linkToPostPage(post.postId)">ポストID: {{ post.postId }}</p>
       <p>タイトル: {{ post.postTitle }}</p>
       <p>ユーザー: {{ post.userName }}</p>
       <p>内容: {{ post.postText }}</p>
@@ -31,7 +31,10 @@ export default {
   methods: {
     ...mapActions('post', [
       'initPosts'
-    ])
+    ]),
+    linkToPostPage(id) {
+      this.$router.push(`post/${id}`)
+    }
   }
   
 

--- a/pages/post/_id.vue
+++ b/pages/post/_id.vue
@@ -1,12 +1,57 @@
 <template>
   <div>
-    <p>{{ $route.params }}</p>
+    <p>ポストID: {{ postId }}</p>
+    <p>タイトル: {{ postTitle }}</p>
+    <p>ユーザー: {{ userName }}</p>
+    <p>内容: {{ postText }}</p>
+    <audio controls :src="audioUrl"></audio>
   </div>
 </template>
 
 <script>
-export default {
+import firebase from '~/plugins/firebase'
+// import { mapActions, mapGetters } from 'vuex'
 
+const db = firebase.firestore()
+const postsCollection = db.collection('posts')
+
+export default {
+  data: () => ({
+    postId: '',
+    postTitle: '',
+    userName: '',
+    postText: '',
+    audioUrl: '',
+  }),
+  created() {
+    // URLパラメータを取得
+    const id = this.$nuxt.$route.params.id
+
+    // this.getPost(id)
+
+    postsCollection.doc(id).get().then(doc => {
+      const data = doc.data()
+      this.postId = data.postId
+      this.postTitle = data.postTitle
+      this.userName = data.userName
+      this.postText = data.postText
+      this.audioUrl = data.audioUrl
+    })
+  },
+
+  // 一応 vuexfire の関数も残しておきます
+  // ↓↓↓↓↓
+  // computed: {
+  //   ...mapGetters('post', [
+  //     'post'
+  //   ])
+  // },
+  // methods: {
+  //   ...mapActions('post', [
+  //     'getPost'
+  //   ]),
+  // }
+  
 }
 </script>
 

--- a/pages/post/_id.vue
+++ b/pages/post/_id.vue
@@ -10,7 +10,6 @@
 
 <script>
 import firebase from '~/plugins/firebase'
-// import { mapActions, mapGetters } from 'vuex'
 
 const db = firebase.firestore()
 const postsCollection = db.collection('posts')
@@ -29,20 +28,6 @@ export default {
     await postsCollection.doc(id).get().then(doc => doc.data())
       return { postId, postTitle, userName, postText, audioUrl }
   },
-
-  // 一応 vuexfire の関数も残しておきます
-  // ↓↓↓↓↓
-  // computed: {
-  //   ...mapGetters('post', [
-  //     'post'
-  //   ])
-  // },
-  // methods: {
-  //   ...mapActions('post', [
-  //     'getPost'
-  //   ]),
-  // }
-  
 }
 </script>
 

--- a/pages/post/_id.vue
+++ b/pages/post/_id.vue
@@ -23,20 +23,11 @@ export default {
     postText: '',
     audioUrl: '',
   }),
-  created() {
-    // URLパラメータを取得
-    const id = this.$nuxt.$route.params.id
-
-    // this.getPost(id)
-
-    postsCollection.doc(id).get().then(doc => {
-      const data = doc.data()
-      this.postId = data.postId
-      this.postTitle = data.postTitle
-      this.userName = data.userName
-      this.postText = data.postText
-      this.audioUrl = data.audioUrl
-    })
+  async asyncData({ params }) {
+    const id = params.id
+    const { postId, postTitle, userName, postText, audioUrl } = 
+    await postsCollection.doc(id).get().then(doc => doc.data())
+      return { postId, postTitle, userName, postText, audioUrl }
   },
 
   // 一応 vuexfire の関数も残しておきます

--- a/pages/post/_id.vue
+++ b/pages/post/_id.vue
@@ -15,19 +15,12 @@ const db = firebase.firestore()
 const postsCollection = db.collection('posts')
 
 export default {
-  data: () => ({
-    postId: '',
-    postTitle: '',
-    userName: '',
-    postText: '',
-    audioUrl: '',
-  }),
   async asyncData({ params }) {
     const id = params.id
     const { postId, postTitle, userName, postText, audioUrl } = 
     await postsCollection.doc(id).get().then(doc => doc.data())
       return { postId, postTitle, userName, postText, audioUrl }
-  },
+  }
 }
 </script>
 

--- a/pages/post/new.vue
+++ b/pages/post/new.vue
@@ -50,8 +50,6 @@
         送信
       </button>
     </div>
-
-    <button @click="getRandomNumber()">生成</button>
   </div>
 </template>
 

--- a/store/post.js
+++ b/store/post.js
@@ -7,16 +7,12 @@ const postsCollection = db.collection('posts')
 
 export const state = () => ({
   posts: [],
-  // post: []
 })
 
 export const getters = {
   posts: state => {
     return state.posts
-  },
-  // post: state => {
-  //   return state.post
-  // }
+  }
 }
 
 export const actions = {
@@ -24,16 +20,6 @@ export const actions = {
   initPosts: firestoreAction(({ bindFirestoreRef }) => {
     bindFirestoreRef('posts', postsCollection)
   }),
-
-  // 第2引数にドキュメント名を渡せば、コレクション以降にもアクセス可能
-  // 拡張性ありだから上の関数書き直しても良いかも
-  // getPost: firestoreAction(({ bindFirestoreRef } , doc) => {
-  //   if (!doc) {
-  //     bindFirestoreRef('post', postsCollection)
-  //     return
-  //   }
-  //   bindFirestoreRef('post', postsCollection.doc(doc))
-  // }),
 
    addPostToFB: firestoreAction(async (context, data) => {
     await postsCollection.doc(data.postId).set(data)

--- a/store/post.js
+++ b/store/post.js
@@ -6,13 +6,17 @@ const db = firebase.firestore()
 const postsCollection = db.collection('posts')
 
 export const state = () => ({
-  posts: []
+  posts: [],
+  // post: []
 })
 
 export const getters = {
   posts: state => {
     return state.posts
-  }
+  },
+  // post: state => {
+  //   return state.post
+  // }
 }
 
 export const actions = {
@@ -20,6 +24,16 @@ export const actions = {
   initPosts: firestoreAction(({ bindFirestoreRef }) => {
     bindFirestoreRef('posts', postsCollection)
   }),
+
+  // 第2引数にドキュメント名を渡せば、コレクション以降にもアクセス可能
+  // 拡張性ありだから上の関数書き直しても良いかも
+  // getPost: firestoreAction(({ bindFirestoreRef } , doc) => {
+  //   if (!doc) {
+  //     bindFirestoreRef('post', postsCollection)
+  //     return
+  //   }
+  //   bindFirestoreRef('post', postsCollection.doc(doc))
+  // }),
 
    addPostToFB: firestoreAction(async (context, data) => {
     await postsCollection.doc(data.postId).set(data)

--- a/store/post.js
+++ b/store/post.js
@@ -6,7 +6,7 @@ const db = firebase.firestore()
 const postsCollection = db.collection('posts')
 
 export const state = () => ({
-  posts: [],
+  posts: []
 })
 
 export const getters = {


### PR DESCRIPTION
refs #8 

- `Firebase` にアクセスして、data プロパティに追加
- data を参照して、_id.vue のテンプレートに表示
-> 上記の方法を `created` から `asyncData` に変更しました
-> `data` を削除しました
- テストとして、`vuexfire` を使って情報を `store` に入れて表示
  - 不具合があったので、こちらはコメントアウトしてあります。
-> コメントは消してあります